### PR TITLE
Create 53-saitek-devices.rules

### DIFF
--- a/flightSim/53-saitek-devices.rules
+++ b/flightSim/53-saitek-devices.rules
@@ -1,0 +1,2 @@
+#Saitek Pro Flight Rudder Pedals
+KERNEL=="event*", SUBSYSTEMS=="input", ATTRS{id/product}=="0763", ATTRS{id/vendor}=="06a3", MODE="0666", TAG+="uaccess"


### PR DESCRIPTION
Adding udev rule so that Logitech/Saitek rudder pedals are recognized correctly